### PR TITLE
Work around https://github.com/chef/bento/issues/661

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -14,7 +14,11 @@ Vagrant.configure("2") do |config|
 
   config.vm.provision "shell", inline: <<-SHELL
     apt-get -qqy update
-    apt-get -qqy upgrade
+
+    # Work around https://github.com/chef/bento/issues/661
+    # apt-get -qqy upgrade
+    DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" upgrade
+
     apt-get -qqy install make zip unzip postgresql
 
     apt-get -qqy install python3 python3-pip


### PR DESCRIPTION
q.v. https://github.com/udacity/fullstack-nanodegree-vm/issues/69

grub-pc has a bug that's keeping noninteractive config from working.
This works around it by forcing super-extra-double noninteractive config.